### PR TITLE
Bv add lazy plugin management and mini plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp/*
 *.swn
 *.swo
 .DS_Store
+lazy-lock.json

--- a/README.md
+++ b/README.md
@@ -47,3 +47,18 @@ Set as ` , `
 ## Filetypes
 
 The unkown filetypes can be defined the type in [nvim/filetype.lua](https://github.com/bvicenzo/nvim/blob/master/filetype.lua).
+
+## Plugins
+
+<details>
+ <summary>[Mini](https://github.com/echasnovski/mini.nvim)</summary>
+  Library of 20+ independent Lua modules improving overall Neovim (version 0.7 and higher) experience with minimal effort. They all share same configuration approaches and general design principles.
+  Installed modules:
+  - [Animate](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-animate.md): Animate common Neovim actions;
+  - [Completion](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-completion.md): Completion and signature help;
+  - [Pairs](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-pairs.md): Allows automatic close opened chars, as (, [, and etc;
+  - [Comment](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-comment.md) Allows comment code using shortcuts;
+  - [Intendscope](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-indentscope.md): Visualize and work with indent scope;
+  - [Splitjoin](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-splitjoin.md): Split and join arguments;
+  - [Cursorword](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-cursorword.md): Automatic highlighting of word under cursor;
+</details>

--- a/init.lua
+++ b/init.lua
@@ -28,6 +28,7 @@ vim.o.ruler = true        -- hightline the number of current line
 vim.o.cursorcolumn = false -- highlight the current column
 vim.o.cursorline = true   -- highlight the current line
 vim.o.termguicolors = true
+vim.o.wrap = false -- Do not wrap lines
 
 -- Set fold method
 vim.cmd("set foldenable")

--- a/init.lua
+++ b/init.lua
@@ -1,6 +1,24 @@
 -- Author: Bruno Vicenzo
 -- Source: https://github.com/bvicenzo/nvim.git
 
+-- Lazy - Package manager
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.loop.fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable", -- latest stable release
+    lazypath,
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+
+-- Lazy load plugins
+require("lazy").setup("plugins")
+
 -- Vim custom options
 vim.g.mapleader = ","           -- change the <leader> to comma(,)
 vim.keymap.set('n', ';', ':')   -- don't need to press the shift key :

--- a/init.lua
+++ b/init.lua
@@ -17,10 +17,10 @@ vim.opt.rtp:prepend(lazypath)
 
 
 -- Lazy load plugins
+vim.g.mapleader = ","           -- change the <leader> to comma(,) need to be before load plugins using Lazy.
 require("lazy").setup("plugins")
 
 -- Vim custom options
-vim.g.mapleader = ","           -- change the <leader> to comma(,)
 vim.keymap.set('n', ';', ':')   -- don't need to press the shift key :
 
 vim.o.number = true       -- show line numbers

--- a/lua/plugins/mini.lua
+++ b/lua/plugins/mini.lua
@@ -19,10 +19,19 @@ return { -- https://github.com/echasnovski/mini.nvim
       },
     })
     require("mini.pairs").setup()
-    require("mini.surround").setup() -- https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-surround.md
-    require("mini.comment").setup()
+    require("mini.surround").setup({ -- https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-surround.md
+      -- Open and close these brakets without adding spaces: https://github.com/echasnovski/mini.nvim/issues/128#issuecomment-1242763766
+      custom_surroundings = {
+        ['('] = { input = { '%b()', '^.().*().$' }, output = { left = '(', right = ')' } },
+        ['['] = { input = { '%b[]', '^.().*().$' }, output = { left = '[', right = ']' } },
+        ['{'] = { input = { '%b{}', '^.().*().$' }, output = { left = '{', right = '}' } },
+        ['<'] = { input = { '%b<>', '^.().*().$' }, output = { left = '<', right = '>' } },
+      },
+    })
+    require("mini.comment").setup() -- Need more understanding
     require("mini.indentscope").setup({
       symbol = '¦'
     })
+    require('mini.splitjoin').setup()
   end
 }

--- a/lua/plugins/mini.lua
+++ b/lua/plugins/mini.lua
@@ -1,0 +1,28 @@
+return { -- https://github.com/echasnovski/mini.nvim
+  "echasnovski/mini.nvim", version = '*',
+  config = function()
+    require("mini.animate").setup()
+    require("mini.completion").setup()
+    require("mini.move").setup({
+      mappings = {
+        -- Move visual selection in Visual mode. Defaults are Alt (Meta) + hjkl.
+        left = '<M-h>',
+        right = '<M-l>',
+        down = '<M-j>',
+        up = '<M-k>',
+
+        -- Move current line in Normal mode
+        line_left = '<M-h>',
+        line_right = '<M-l>',
+        line_down = '<M-j>',
+        line_up = '<M-k>',
+      },
+    })
+    require("mini.pairs").setup()
+    require("mini.surround").setup() -- https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-surround.md
+    require("mini.comment").setup()
+    require("mini.indentscope").setup({
+      symbol = '¦'
+    })
+  end
+}


### PR DESCRIPTION
Add [lazy](https://github.com/folke/lazy.nvim) neovim plugins management.
Add first plugin mini with following modules:
<details>
 <summary>[Mini](https://github.com/echasnovski/mini.nvim)</summary>
  Library of 20+ independent Lua modules improving overall Neovim (version 0.7 and higher) experience with minimal effort. They all share same configuration approaches and general design principles.
  Installed modules:
  - [Animate](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-animate.md): Animate common Neovim actions;
  - [Completion](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-completion.md): Completion and signature help;
  - [Pairs](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-pairs.md): Allows automatic close opened chars, as (, [, and etc;
  - [Comment](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-comment.md) Allows comment code using shortcuts;
  - [Intendscope](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-indentscope.md): Visualize and work with indent scope;
  - [Splitjoin](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-splitjoin.md): Split and join arguments;
  - [Cursorword](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-cursorword.md): Automatic highlighting of word under cursor;
</details>