### PR TITLE
Add Lua line and devicons plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,13 @@ The unkown filetypes can be defined the type in [nvim/filetype.lua](https://gith
   Plugin page [here](https://github.com/Mofiqul/dracula.nvim).
   Plugin to add [Dracula theme](https://draculatheme.com/) to Nvim.
 </details>
+<details>
+ <summary>Dev icons</summary>
+  Plugin page [here](https://github.com/nvim-tree/nvim-web-devicons).
+  Plugin to add dev icons as filetypes and etc to Nvim.
+</details>
+<details>
+ <summary>Lualine</summary>
+  Plugin page [here](https://github.com/nvim-lualine/lualine.nvim).
+  Plugin to add a status line integrated with devicons.
+</details>

--- a/lua/plugins/devicons.lua
+++ b/lua/plugins/devicons.lua
@@ -1,0 +1,6 @@
+return { -- https://github.com/echasnovski/mini.nvim
+  "nvim-tree/nvim-web-devicons", version = '*',
+  config = function()
+    require("nvim-web-devicons").setup()
+  end
+}

--- a/lua/plugins/lualine.lua
+++ b/lua/plugins/lualine.lua
@@ -1,0 +1,8 @@
+return { -- https://github.com/echasnovski/mini.nvim
+  "nvim-lualine/lualine.nvim", version = '*',
+  config = function()
+    require("lualine").setup({
+      requires = { 'nvim-tree/nvim-web-devicons', opt = true }
+    })
+  end
+}


### PR DESCRIPTION
Add the following plugins:
<details>
 <summary>Dev icons</summary>
  Plugin page [here](https://github.com/nvim-tree/nvim-web-devicons).
  Plugin to add dev icons as filetypes and etc to Nvim.
</details>
<details>
 <summary>Lualine</summary>
  Plugin page [here](https://github.com/nvim-lualine/lualine.nvim).
  Plugin to add a status line integrated with devicons.
</details>