### PR TITLE
Add Git Signs and Git Linker plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,15 @@ The unkown filetypes can be defined the type in [nvim/filetype.lua](https://gith
   - `shift+>`: Move file/buffers/git tabs for right;
   - `shift+<`: Move file/buffers/git tabs for left;
 </details>
+<details>
+ <summary>Git signs</summary>
+  Plugin page [here](https://github.com/lewis6991/gitsigns.nvim).
+ 
+ Plugin to help to work on git functions.
+  Main commands:
+
+  - `<leader>tb`: Show/Hide gitblame on current line;
+  - `<leader>hb`: Show the full commit message;
+  - `<leader>hd`: Show git diff on file;
+  - `<leader>hp`: Show git diff for current change;
+</details>

--- a/README.md
+++ b/README.md
@@ -103,3 +103,13 @@ The unkown filetypes can be defined the type in [nvim/filetype.lua](https://gith
   - `<leader>hd`: Show git diff on file;
   - `<leader>hp`: Show git diff for current change;
 </details>
+<details>
+ <summary>Git linker</summary>
+  Plugin page [here](https://github.com/ruifm/gitlinker.nvim).
+ 
+ Plugin to generate link and access files on sources as github and gitlab.
+  Main commands:
+
+  - `<leader>gy`: Generate link and copy to clipboard;
+  - `<leader>of`: Generate link and open in default browser;
+</details>

--- a/lua/plugins/gitlinker.lua
+++ b/lua/plugins/gitlinker.lua
@@ -1,0 +1,12 @@
+return { -- Files Tree
+  "ruifm/gitlinker.nvim", version = "*", -- https://github.com/nvim-neo-tree/neo-tree.nvim
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+  },
+  config = function()
+    require("gitlinker").setup()
+
+    vim.api.nvim_set_keymap('n', '<leader>of', '<cmd>lua require("gitlinker").get_buf_range_url("n", {action_callback = require"gitlinker.actions".open_in_browser})<cr>', {silent = true})
+    vim.api.nvim_set_keymap('v', '<leader>of', '<cmd>lua require("gitlinker").get_buf_range_url("v", {action_callback = require"gitlinker.actions".open_in_browser})<cr>', {})
+  end
+}

--- a/lua/plugins/gitsigns.lua
+++ b/lua/plugins/gitsigns.lua
@@ -1,0 +1,51 @@
+return { -- https://github.com/echasnovski/mini.nvim
+  "lewis6991/gitsigns.nvim", version = '*',
+  config = function()
+    require("gitsigns").setup({
+      current_line_blame = true, -- Toggle with `:Gitsigns toggle_current_line_blame`
+      current_line_blame_opts = {
+        delay = 200, -- 0.2s
+      },
+      on_attach = function(bufnr)
+        local gs = package.loaded.gitsigns
+
+        local function map(mode, l, r, opts)
+          opts = opts or {}
+          opts.buffer = bufnr
+          vim.keymap.set(mode, l, r, opts)
+        end
+
+        -- Navigation
+        map('n', ']c', function()
+          if vim.wo.diff then return ']c' end
+          vim.schedule(function() gs.next_hunk() end)
+          return '<Ignore>'
+        end, {expr=true})
+
+        map('n', '[c', function()
+          if vim.wo.diff then return '[c' end
+          vim.schedule(function() gs.prev_hunk() end)
+          return '<Ignore>'
+        end, {expr=true})
+
+        -- Actions
+        map('n', '<leader>hs', gs.stage_hunk)
+        map('n', '<leader>hr', gs.reset_hunk)
+        map('v', '<leader>hs', function() gs.stage_hunk {vim.fn.line("."), vim.fn.line("v")} end)
+        map('v', '<leader>hr', function() gs.reset_hunk {vim.fn.line("."), vim.fn.line("v")} end)
+        map('n', '<leader>hS', gs.stage_buffer)
+        map('n', '<leader>hu', gs.undo_stage_hunk)
+        map('n', '<leader>hR', gs.reset_buffer)
+        map('n', '<leader>hp', gs.preview_hunk)
+        map('n', '<leader>hb', function() gs.blame_line{full=true} end)
+        map('n', '<leader>tb', gs.toggle_current_line_blame)
+        map('n', '<leader>hd', gs.diffthis)
+        map('n', '<leader>hD', function() gs.diffthis('~') end)
+        map('n', '<leader>td', gs.toggle_deleted)
+
+        -- Text object
+        map({'o', 'x'}, 'ih', ':<C-U>Gitsigns select_hunk<CR>')
+      end
+    })
+  end
+}


### PR DESCRIPTION
<details>
 <summary>Git signs</summary>
  Plugin page [here](https://github.com/lewis6991/gitsigns.nvim).

 Plugin to help to work on git functions.
  Main commands:

  - `<leader>tb`: Show/Hide gitblame on current line;
  - `<leader>hb`: Show the full commit message;
  - `<leader>hd`: Show git diff on file;
  - `<leader>hp`: Show git diff for current change;
</details>
<details>
 <summary>Git linker</summary>
  Plugin page [here](https://github.com/ruifm/gitlinker.nvim).

 Plugin to generate link and access files on sources as github and gitlab.
  Main commands:

  - `<leader>gy`: Generate link and copy to clipboard;
  - `<leader>of`: Generate link and open in default browser;
</details>